### PR TITLE
services - apply graphql for request photos

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "format": "npm run eclint && npm run eslint --fix && npm run prettier --write && npm run lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.29.5",
     "antd": "4.24.10",
+    "graphql-request": "^6.0.0",
     "next": "13.4.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -28,6 +30,7 @@
     "@types/react-dom": "18.2.4",
     "@types/styled-components": "^5.1.26",
     "eclint": "^2.8.1",
+    "encoding": "^0.1.13",
     "eslint": "8.40.0",
     "eslint-config-next": "13.4.1",
     "husky": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,15 @@
 lockfileVersion: '6.0'
 
 dependencies:
+  '@tanstack/react-query':
+    specifier: ^4.29.5
+    version: 4.29.5(react-dom@18.2.0)(react@18.2.0)
   antd:
     specifier: 4.24.10
     version: 4.24.10(react-dom@18.2.0)(react@18.2.0)
+  graphql-request:
+    specifier: ^6.0.0
+    version: 6.0.0(encoding@0.1.13)(graphql@16.6.0)
   next:
     specifier: 13.4.1
     version: 13.4.1(react-dom@18.2.0)(react@18.2.0)
@@ -36,6 +42,9 @@ devDependencies:
   eclint:
     specifier: ^2.8.1
     version: 2.8.1
+  encoding:
+    specifier: ^0.1.13
+    version: 0.1.13
   eslint:
     specifier: 8.40.0
     version: 8.40.0
@@ -280,6 +289,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.6.0):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 16.6.0
+    dev: false
+
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
@@ -480,6 +497,28 @@ packages:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.5.0
+    dev: false
+
+  /@tanstack/query-core@4.29.5:
+    resolution: {integrity: sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==}
+    dev: false
+
+  /@tanstack/react-query@4.29.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    dependencies:
+      '@tanstack/query-core': 4.29.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
   /@types/hoist-non-react-statics@3.3.1:
@@ -1151,6 +1190,14 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
+  /cross-fetch@3.1.5(encoding@0.1.13):
+    resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
+    dependencies:
+      node-fetch: 2.6.7(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /cross-spawn@4.0.2:
     resolution: {integrity: sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==}
     dependencies:
@@ -1402,6 +1449,11 @@ packages:
       highlight.js: 9.12.0
       lowlight: 1.9.2
     dev: true
+
+  /encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    dependencies:
+      iconv-lite: 0.6.3
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2173,6 +2225,23 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
+  /graphql-request@6.0.0(encoding@0.1.13)(graphql@16.6.0):
+    resolution: {integrity: sha512-2BmHTuglonjZvmNVw6ZzCfFlW/qkIPds0f+Qdi/Lvjsl3whJg2uvHmSvHnLWhUTEw6zcxPYAHiZoPvSVKOZ7Jw==}
+    peerDependencies:
+      graphql: 14 - 16
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      cross-fetch: 3.1.5(encoding@0.1.13)
+      graphql: 16.6.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /graphql@16.6.0:
+    resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
+
   /gulp-exclude-gitignore@1.2.0:
     resolution: {integrity: sha512-J3LCmz9C1UU1pxf5Npx6SNc5o9YQptyc9IHaqLiBlihZmg44jaaTplWUZ0JPQkMdOTae0YgEDvT9TKlUWDSMUA==}
     dependencies:
@@ -2312,6 +2381,12 @@ packages:
     dependencies:
       safer-buffer: 2.1.2
     dev: true
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -2989,6 +3064,19 @@ packages:
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
+
+  /node-fetch@2.6.7(encoding@0.1.13):
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      encoding: 0.1.13
+      whatwg-url: 5.0.0
+    dev: false
 
   /normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
@@ -4053,7 +4141,6 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -4472,6 +4559,10 @@ packages:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
     dev: false
 
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
@@ -4561,6 +4652,14 @@ packages:
       punycode: 2.3.0
     dev: true
 
+  /use-sync-external-store@1.2.0(react@18.2.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -4617,6 +4716,17 @@ packages:
       remove-trailing-separator: 1.1.0
       replace-ext: 1.0.1
     dev: true
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 @import '~antd/es/select/style/index.css';
 @import '~antd/es/table/style/index.css';
 @import '~antd/es/pagination/style/index.css';
+@import '~antd/es/spin/style/index.css';
 
 :root {
   --max-width: 1100px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,14 @@
+'use client'
+
 import AppLayout from '@components/AppLayout'
 import './globals.css'
 import { Inter } from 'next/font/google'
 import StyledComponentsRegistry from '@libs/registry'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const inter = Inter({ subsets: ['latin'] })
 
-export const metadata = {
-  title: 'Demo App',
-  description: 'Build a search application that searches on a collection of photo data and display the result in a table format to a user',
-}
+const queryClient = new QueryClient()
 
 export default function RootLayout({
   children,
@@ -18,9 +18,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className} suppressHydrationWarning>
-        <StyledComponentsRegistry>
-          <AppLayout>{children}</AppLayout>
-        </StyledComponentsRegistry>
+        <QueryClientProvider client={queryClient}>
+          <StyledComponentsRegistry>
+            <AppLayout>{children}</AppLayout>
+          </StyledComponentsRegistry>
+        </QueryClientProvider>
       </body>
     </html>
   )

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -8,7 +8,7 @@ import DataTableSearch from './search'
 type Column = {
   key: string,
   title: string,
-  render?: (cell: any, row?: Record<string, any>) => any
+  render?: (cell: any, row?: Record<string, any>) => any,
 }
 
 export type DataTableRequest = {
@@ -22,13 +22,12 @@ type DataTableProps = {
   data: object[],
   pagination?: TablePaginationConfig,
   search?: boolean,
+  loading?: boolean,
   onRequest?: (request: DataTableRequest) => void,
 }
 
 const DataTable = (props: DataTableProps) => {
-  const { columns: propColumns, data: propData, pagination, search, onRequest } = props || {}
-
-  const [data, setData] = useState(propData)
+  const { columns: propColumns, data, pagination, search, loading, onRequest } = props || {}
 
   const [requestState, setRequestState] = useState<DataTableRequest>({ query: '', page: 1, limit: 10 })
 
@@ -56,6 +55,7 @@ const DataTable = (props: DataTableProps) => {
         dataSource={data}
         columns={columns}
         pagination={pagination}
+        loading={loading}
         onChange={(pag) => changeRequestState({ page: pag.current, limit: pag.pageSize })}
       />
     </Wrapper>

--- a/src/interfaces/pagination.ts
+++ b/src/interfaces/pagination.ts
@@ -1,0 +1,6 @@
+export interface PaginationResult<T> {
+  data: T[];
+  meta: {
+    totalCount: number;
+  }
+}

--- a/src/interfaces/photo.ts
+++ b/src/interfaces/photo.ts
@@ -1,0 +1,6 @@
+export interface Photo {
+  id: number;
+  title: String;
+  url: String;
+  thumbnailUrl: String;
+}

--- a/src/libs/graphql.ts
+++ b/src/libs/graphql.ts
@@ -1,0 +1,5 @@
+import { GraphQLClient } from "graphql-request";
+
+const endpoint = "https://graphqlzero.almansi.me/api";
+
+export const graphQLClient = new GraphQLClient(endpoint);

--- a/src/services/photos.ts
+++ b/src/services/photos.ts
@@ -1,0 +1,36 @@
+import { PaginationResult } from '@interfaces/pagination'
+import { Photo } from '@interfaces/photo'
+import { graphQLClient } from '@libs/graphql'
+
+export const filterAllPhotos = async (q: string, limit: number, page: number): Promise<PaginationResult<Photo>> => {
+  const query = `
+        query ($options: PageQueryOptions) {
+          photos(options: $options) {
+            data {
+              id
+              title
+              url
+              thumbnailUrl
+            }
+            meta {
+              totalCount
+            }
+          }
+        }
+      `
+  const variables = {
+    options: {
+      paginate: {
+        page,
+        limit
+      },
+      search: {
+        q
+      }
+    }
+  }
+
+  const { photos } = await graphQLClient.request<any>(query, variables)
+
+  return photos
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,9 @@
     ],
     "paths": {
       "@components/*": ["./src/components/*"],
-      "@libs/*": ["./src/libs/*"]
+      "@interfaces/*": ["./src/interfaces/*"],
+      "@libs/*": ["./src/libs/*"],
+      "@services/*": ["./src/services/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Add some stack for query API.

**@tanstack/react-query** is a powerful library for managing data in your application. It provides a cache for your API responses and automatically fetches data only when it's needed. This can greatly improve the performance of your application by reducing the number of unnecessary requests.

**graphql-request** is a lightweight library for making GraphQL requests. It provides a simple and easy-to-use API for working with GraphQL and can be easily integrated with @tanstack/react-query.

using **@tanstack/react-query** and **graphql-request** together can greatly improve the performance, simplicity, and maintainability of your application's data management code.